### PR TITLE
hotfix for min_width when using major axis as reference

### DIFF
--- a/radial_profile/radial_profile_utils.py
+++ b/radial_profile/radial_profile_utils.py
@@ -858,13 +858,16 @@ def fit_annuli(
     """
 
     def _append_annulus(_num):
-        # First, assume _min_width_ax == "minor"
-        b_in = _num * min_width
-        a_in = b_in * b_to_a_factor
-        if min_width_ax == "major":
-            b_in, a_in = a_in, b_in
-        b_out = b_in + min_width
-        a_out = b_out * b_to_a_factor
+        if min_width_ax == "minor":
+            b_in = _num * min_width
+            a_in = b_in * b_to_a_factor
+            b_out = b_in + min_width
+            a_out = b_out * b_to_a_factor
+        else:
+            a_in = _num * min_width
+            b_in = a_in / b_to_a_factor
+            a_out = a_in + min_width
+            b_out = a_out / b_to_a_factor
         a_ins.append(a_in)
         a_outs.append(a_out)
         b_ins.append(b_in)


### PR DESCRIPTION
This PR fixes a bug that occurs when the user selects `major` as the `min_width_ax`, which would cause the annuli to be larger than intended.

Credit to @ndemarch for spotting the issue and for the fix.